### PR TITLE
use an rgba Pix array instead of converting each x,y coord to a Color

### DIFF
--- a/pkg/diffimg/diffimg.go
+++ b/pkg/diffimg/diffimg.go
@@ -129,7 +129,7 @@ func GetRatio(im1, im2 image.Image, ignoreAlpha bool) float64 {
 
 	var sum uint64
 	for i := range rgba1.Pix {
-		if ignoreAlpha && i%3 == 0 {
+		if ignoreAlpha && (i+1)%4 == 0 {
 			continue
 		}
 		sum += uint64(absDiffUint8(rgba1.Pix[i], rgba2.Pix[i]))

--- a/pkg/diffimg/diffimg.go
+++ b/pkg/diffimg/diffimg.go
@@ -112,6 +112,9 @@ func sumPixelDiff(im1, im2 image.Image, x, y int, ignoreAlpha bool) uint16 {
 }
 
 func toRGBA(im image.Image) *image.RGBA {
+	if rgba, ok := im.(*image.RGBA); ok {
+		return rgba
+	}
 	rect := im.Bounds()
 	rgba := image.NewRGBA(rect)
 	draw.Draw(rgba, rect, im, rect.Min, draw.Src)

--- a/pkg/diffimg/diffimg.go
+++ b/pkg/diffimg/diffimg.go
@@ -137,7 +137,7 @@ func GetRatio(im1, im2 image.Image, ignoreAlpha bool) float64 {
 
 	max := float64(len(rgba1.Pix)) * maxChannelVal
 	if ignoreAlpha {
-		max *= 3 / 4 // only RGB, not A
+		max *= 0.75 // only RGB, not A
 	}
 
 	return float64(sum) / max


### PR DESCRIPTION
An illustration of how you might make a more apples-to-apples comparison, with quite different performance characteristics.

```
~/code/src/github.com/nicolashahn/diffimg-go (master) 🐵  go build ./main.go && time ./main ~/Desktop/test-image-1.png ~/Desktop/test-image-2.png
0.12764707841506104

real	0m3.291s
user	0m3.100s
sys	0m0.197s
~/code/src/github.com/nicolashahn/diffimg-go (master) 🐬  git checkout faster-array
Switched to branch 'faster-array'
Your branch is up to date with 'origin/faster-array'.
~/code/src/github.com/nicolashahn/diffimg-go (faster-array) 🐰  go build ./main.go && time ./main ~/Desktop/test-image-1.png ~/Desktop/test-image-2.png
0.12764707841506104

real	0m1.499s
user	0m1.386s
sys	0m0.131s
```